### PR TITLE
Remove asterisk

### DIFF
--- a/gen.rb
+++ b/gen.rb
@@ -119,7 +119,7 @@ class Generator
     trs = page.transitions.map do |trn|
       next unless trn
       # TODO: structurize
-      "<router-link to='/#{trn[2].downcase.strip}'>#{trn.first}</router-link>/"
+      "<router-link to='/#{trn[2].strip.gsub(/^\*/,'').downcase}'>#{trn.first}</router-link>/"
     end
     pagesrc.gsub!('===LINK===', trs.join)
 


### PR DESCRIPTION
#9 先頭にアスタリスクがついたままのリンクが生成される
自分であげた Issue 修正してみました（出すぎたマネでしたら、すみません、、、）
fork -> PR がやってみたく

## 修正内容

画面名の先頭のアスタリスク削除

## 一言

修正漏れあったら申し訳ございません。
自分も何かお役に立ちたかったので、頑張ってみました！
ご確認お願いいたいします。